### PR TITLE
Capture subcommand examples under `--help`

### DIFF
--- a/cmd/contains.go
+++ b/cmd/contains.go
@@ -9,10 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	containsExample = "# Check whether an IPv4 CIDR range contains a given IPv4 address\n" +
+		"cidr contains 10.0.0.0/16 10.0.14.5\n" +
+		"\n" +
+		"# Check whether an IPv6 CIDR range contains a given IPv6 address\n" +
+		"cidr contains 2001:db8:1234:1a00::/106 2001:db8:1234:1a00::\n"
+)
+
 var (
 	containsCmd = &cobra.Command{
-		Use:   "contains",
-		Short: "Checks whether an IP address belongs to a CIDR range",
+		Use:     "contains",
+		Short:   "Checks whether an IP address belongs to a CIDR range",
+		Example: containsExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				fmt.Println("error: provide a CIDR range and an IP address")

--- a/cmd/count.go
+++ b/cmd/count.go
@@ -9,10 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	countExample = "# Return the count of all distinct host addresses within a given IPv4 CIDR range\n" +
+		"cidr count 10.0.0.0/16\n" +
+		"\n" +
+		"# Return the count of all distinct host addresses within a given IPv6 CIDR range\n" +
+		"cidr count 2001:db8:1234:1a00::/106\n"
+)
+
 var (
 	countCmd = &cobra.Command{
-		Use:   "count",
-		Short: "Return the count of distinct host addresses in a given CIDR range",
+		Use:     "count",
+		Short:   "Return the count of all distinct host addresses in a given CIDR range",
+		Example: countExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				fmt.Println("error: provide a CIDR range")

--- a/cmd/overlaps.go
+++ b/cmd/overlaps.go
@@ -9,9 +9,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	overlapsExample = "# Check whether 2 IPv4 CIDR ranges overlap\n" +
+		"cidr overlaps 10.0.0.0/16 10.0.14.0/22\n" +
+		"\n" +
+		"# Check whether 2 IPv6 CIDR ranges overlap\n" +
+		"cidr overlaps 2001:db8:1111:2222:1::/80 2001:db8:1111:2222:1:1::/96\n"
+)
+
 var overlapsCmd = &cobra.Command{
-	Use:   "overlaps",
-	Short: "Checks if a CIDR range overlaps with another CIDR range",
+	Use:     "overlaps",
+	Short:   "Checks if a CIDR range overlaps with another CIDR range",
+	Example: overlapsExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 2 {
 			fmt.Println("error: provide 2 CIDR ranges")


### PR DESCRIPTION
As proposed in #39, we should capture some examples under the `--help` flag for each subcommand.