### PR TITLE
feat: remember the network and broadcast address

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ cidr count 10.0.0.0/16
 65534
 ```
 
-Or with an edge case:
+Or with large prefixes like point-to-point links:
 
 ```
 $ cidr count count 172.16.18.0/31

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This also works with IPv6 addresses, for example:
 ```
 $ cidr contains 2001:db8:1234:1a00::/106 2001:db8:1234:1a00::
 true
-``` 
+```
 
 ### Count distinct host addresses
 
@@ -41,15 +41,22 @@ To get all distinct host addresses part of a given CIDR range:
 
 ```
 $ cidr count 10.0.0.0/16
-65536
+65534
 ```
 
-This also works with IPv6 addresses, for example:
+Or with an edge case:
+
+```
+$ cidr count count 172.16.18.0/31
+2
+```
+
+This also works with very small CIDR ranges, like a point-to-point link:
 
 ```
 $ cidr count 2001:db8:1234:1a00::/106
 4194304
-``` 
+```
 
 ### CIDR range intersection
 
@@ -65,9 +72,9 @@ This also works with IPv6 addresses, for example:
 ```
 $ cidr overlaps 2001:db8:1111:2222:1::/80 2001:db8:1111:2222:1:1::/96
 true
-``` 
+```
 
 ## Contributing
 
-Contributions are highly appreciated and always welcome. 
+Contributions are highly appreciated and always welcome.
 Have a look through existing [Issues](https://github.com/bschaatsbergen/cidr/issues) and [Pull Requests](https://github.com/bschaatsbergen/cidr/pulls) that you could help with.

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -6,7 +6,18 @@ import (
 
 func AddressCount(network *net.IPNet) uint64 {
 	prefixLen, bits := network.Mask.Size()
-	return 1 << (uint64(bits) - uint64(prefixLen))
+
+	// Check if network is IPv4 or IPv6
+	if network.Mask != nil {
+		// Handle edge cases
+		switch prefixLen {
+			case 32: return 1
+			case 31: return 2
+		}
+	}
+
+	// Remember to subtract the network address and broadcast address
+	return 1 << (uint64(bits) - uint64(prefixLen)) - 2
 }
 
 func ParseCIDR(network string) (*net.IPNet, error) {


### PR DESCRIPTION
I noticed that the count function didn't consider that a subnet requires a network and broadcast address. I also added the edge case of a /31 subnet and how that is handled by providers (even though it's not compliant ;))