### PR TITLE
chore: update install instructions, now using homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A CLI to perform various actions on CIDR ranges
 To install cidr using brew, simply do the below.
 
 ```sh
-brew tap bschaatsbergen/cidr
 brew install cidr
 ```
 


### PR DESCRIPTION
cidr is now part of homebrew core, since https://github.com/Homebrew/homebrew-core/pull/156041 - this PR updates the install instructions in the README