### PR TITLE
chore: align description with description of `cidr` in homebrew-core

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ brews:
       name: homebrew-cidr
     name: cidr
     homepage: "https://github.com/bschaatsbergen/cidr"
-    description: "A CLI to perform various actions on CIDR ranges"
+    description: "CLI to perform various actions on CIDR ranges"
     license: "MIT"
     skip_upload: auto
     commit_author:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cidr
 [![Release](https://github.com/bschaatsbergen/cidr/actions/workflows/goreleaser.yaml/badge.svg)](https://github.com/bschaatsbergen/cidr/actions/workflows/goreleaser.yaml) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/bschaatsbergen/cidr) ![GitHub commits since latest release (by SemVer)](https://img.shields.io/github/commits-since/bschaatsbergen/cidr/latest) [![Go Reference](https://pkg.go.dev/badge/github.com/bschaatsbergen/cidr.svg)](https://pkg.go.dev/github.com/bschaatsbergen/cidr)
 
-A CLI to perform various actions on CIDR ranges
+CLI to perform various actions on CIDR ranges
 
 ## Brew
 To install cidr using brew, simply do the below.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ var (
 
 	rootCmd = &cobra.Command{
 		Use:     "cidr",
-		Short:   "cidr - A CLI to perform various actions on CIDR ranges",
+		Short:   "cidr - CLI to perform various actions on CIDR ranges",
 		Version: version, // The version is set during the build by making using of `go build -ldflags`
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()


### PR DESCRIPTION
Be aligned with the description we use in homebrew-core, see: https://formulae.brew.sh/formula/cidr#default