### PR TITLE
chore: add binary `cidr` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+cidr
 
 # cidr binary
 ./cobra
@@ -16,4 +17,3 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-cidr

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+cidr


### PR DESCRIPTION
To prevent committing the binary on accident.