### PR TITLE
fix: Fixed help text for explain command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ cidr
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea/

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -19,7 +19,7 @@ var (
 		Short: "Provides information about a CIDR range",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
-				fmt.Println("error: provide a CIDR range and an IP address")
+				fmt.Println("error: provide a CIDR range")
 				fmt.Println("See 'cidr contains -h' for help and examples")
 				os.Exit(1)
 			}


### PR DESCRIPTION
Fixed the help text for the explain command. It states it needs both a CIDR range and an IP address, which is incorrect.