### PR TITLE
chore: bumped actions/labeler to v5

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,16 +1,26 @@
 github-actions:
-- '.github/**'
-- '.goreleaser.yaml'
+  - changed-files:
+      - any-glob-to-any-file:
+        - '.github/**'
+        - '.goreleaser.yaml'
 
-dependencies: 
-- 'go.mod'
-- 'go.sum'
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+        - 'go.mod'
+        - 'go.sum'
 
 documentation:
-- 'README.md'
+  - changed-files:
+      - any-glob-to-any-file:
+        - 'README.md'
 
 legal:
-- 'LICENSE'
+  - changed-files:
+      - any-glob-to-any-file:
+        - 'LICENSE'
 
 tests:
-- '**/*_test.go'
+  - changed-files:
+      - any-glob-to-any-file:
+        - '**/*_test.go'

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         configuration-path: .github/labeler.yaml


### PR DESCRIPTION
## What
Bumped actions/labeler to v5

## Why
v5 is now GA

## References
https://github.com/actions/labeler
