### PR TITLE
chore: rename `Address Count` to `Host Addresses`

### DIFF
--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -123,7 +123,7 @@ func explain(details *networkDetailsToDisplay) {
 	} else if details.BroadcastAddressHasError && details.IsIPV4Network {
 		fmt.Printf(color.RedString("Broadcast Address:\t ")+"%s\n", details.BroadcastAddress)
 	}
-	fmt.Printf(color.BlueString("Address Count:\t\t ")+"%s\n", details.Count)
+	fmt.Printf(color.BlueString("Host Addresses:\t\t ")+"%s\n", details.Count)
 
 	if details.PrefixLength > 1 {
 		lengthIndicator = "bits"


### PR DESCRIPTION
## What
* Renamed `Address Count:` in the `explain` output to `Host Addresses`.

## Why
* To avoid any misunderstandings, the number indicates the count of host addresses as we subtract 2 to account for the base address and the broadcast address.

## References
* Closes #90
