### PR TITLE
chore: don't remove the network address and broadcast address

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -32,8 +32,7 @@ func GetAddressCount(network *net.IPNet) uint64 {
 		}
 	}
 
-	// Subtract the network address and broadcast address (2) from the total number of addresses.
-	return 1<<(uint64(bits)-uint64(prefixLen)) - 2
+	return 1 << (uint64(bits) - uint64(prefixLen))
 }
 
 // ContainsAddress checks if the given IP network contains the specified IP address.

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -44,12 +44,12 @@ func TestGetAddressCount(t *testing.T) {
 		{
 			name:          "Return the count of all distinct host addresses in a common IPv4 CIDR",
 			cidr:          IPv4CIDR,
-			expectedCount: 65534,
+			expectedCount: 65536,
 		},
 		{
 			name:          "Return the count of all distinct host addresses in a common IPv6 CIDR",
 			cidr:          IPv6CIDR,
-			expectedCount: 4194302,
+			expectedCount: 4194304,
 		},
 		{
 			name:          "Return the count of all distinct host addresses in an uncommon (large prefix) IPv4 CIDR",


### PR DESCRIPTION
## What
* We always removed the network address and broadcast address from the count, but every CIDR calculator includes these.
