### PR TITLE
bump to v6.0.1 of the golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Run linters
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64
         with:
           version: latest
           skip-pkg-cache: true


### PR DESCRIPTION
## What
* Bumps the golangci-lint-action to v6.0.1