### PR TITLE
chore: change `vet` to `govet`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,4 +38,4 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet


### PR DESCRIPTION
## Why
* `vet` is deprecated. The linter has been renamed to: `govet`.
