### PR TITLE
chore: print truncation as a blue string

### DIFF
--- a/cmd/divide.go
+++ b/cmd/divide.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bschaatsbergen/cidr/pkg/core"
 	"github.com/bschaatsbergen/cidr/pkg/helper"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -90,7 +91,7 @@ func printNetworkPartitions(networks []net.IPNet) {
 		for i := 0; i < truncateLimit/2; i++ {
 			fmt.Println(networks[i].String())
 		}
-		fmt.Println("......")
+		fmt.Println(color.BlueString("......"))
 		for i := networkCount - truncateLimit/2; i < networkCount; i++ {
 			fmt.Println(networks[i].String())
 		}


### PR DESCRIPTION
## What
* Print the truncation as part of a large `$ cidr divide` using a blue string.

## Why
* Visibility of where truncation starts and to be in line with tool branding.

