### PR TITLE
chore: pin `v1.26.2` before we upgrade to goreleaser ~> v2

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: v1.26.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
## What
* Pin goreleaser to [v1.26.2](https://github.com/goreleaser/goreleaser/releases/tag/v1.26.2), before we upgrade to the "latest" ~> v2 release.

## Why
* Prevent breaking the release job.
