### PR TITLE
docs: add Debian & Ubuntu install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # cidr
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/bschaatsbergen/cidr) [![Go Reference](https://pkg.go.dev/badge/github.com/bschaatsbergen/cidr.svg)](https://pkg.go.dev/github.com/bschaatsbergen/cidr)
 
-Simplifies IPv4/IPv6 CIDR network prefix management with counting, overlap checking, explanation, and subdivision
+Simplifies IPv4/IPv6 CIDR network prefix management with counting, overlap checking, explanation, and subdivision.
+
+## Debian & Ubuntu
+To install cidr using apt, simply run:
+
+```sh
+apt install cidr
+```
 
 ## Brew
 To install cidr using brew, simply run:


### PR DESCRIPTION
## What
* Update README.MD to include an `apt install cidr` example.

## Why
* `cidr` is _almost_ available on Debian, and is already available on Ubuntu Oracular.

## References
* Closes #88 
* https://launchpad.net/ubuntu/oracular/+source/cidr
* https://tracker.debian.org/pkg/cidr
